### PR TITLE
[Fix✏️]폴더별 요약 칸 조정

### DIFF
--- a/frontend/src/pages/HomePage/Home.tsx
+++ b/frontend/src/pages/HomePage/Home.tsx
@@ -160,6 +160,8 @@ const Home = () => {
         })
       }
     }
+    console.log('폴더 추가')
+    console.log(folders)
   }
 
   const handleFolderDeleted = (sector: string, deletedFolderTitle: string) => {
@@ -175,6 +177,8 @@ const Home = () => {
         return folder
       }),
     )
+    fetchFolders()
+    console.log('폴더 삭제 후 재로딩')
 
     console.log(folders)
   }

--- a/frontend/src/pages/ProjectDetailPage/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetailPage/ProjectDetail.tsx
@@ -193,6 +193,8 @@ const ProjectDetail = () => {
 
   const handleFileDeleted = (fileName: string) => {
     setFileFinals(prevFiles => prevFiles.filter(file => file.name !== fileName))
+    fetchFiles()
+    console.log('파일 삭제하고 다시 로딩')
   }
 
   useEffect(() => {

--- a/frontend/src/pages/ProjectDetailPage/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetailPage/ProjectDetail.tsx
@@ -264,13 +264,16 @@ const ProjectDetail = () => {
                       Check summary information of my folder!
                     </button>
                     {showDetails && (
-                      <div className='pl-10 pr-10 pt-1 pb-3 bg-gray-100 rounded-xl shadow mb-4'>
-                        <div className='mt-3' style={{ width: containerWidth }}>
-                          <span className='block text-sm'>
-                            {folderPortfolio}
-                          </span>
-                        </div>
+                      <div className='pl-10 pr-10 pt-3 pb-3 bg-gray-100 rounded-xl shadow mb-4'>
+                        {/* <div className='mt-3' style={{ width: containerWidth }}> */}
+                        <span
+                          className='block text-sm'
+                          style={{ width: '100%' }}
+                        >
+                          {folderPortfolio}
+                        </span>
                       </div>
+                      // </div>
                     )}
                   </>
                 ) : (

--- a/frontend/src/pages/ProjectDetailPage/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetailPage/ProjectDetail.tsx
@@ -270,7 +270,7 @@ const ProjectDetail = () => {
                         {/* <div className='mt-3' style={{ width: containerWidth }}> */}
                         <span
                           className='block text-sm'
-                          style={{ width: '100%' }}
+                          style={{ width: '100%', textAlign: 'justify' }}
                         >
                           {folderPortfolio}
                         </span>


### PR DESCRIPTION
## #️⃣연관된 이슈

#16 

## 💡 핵심적으로 구현된 사항
<img width="1698" alt="image" src="https://github.com/user-attachments/assets/e4db655f-5995-40f3-b7b3-a3c89e8ce31e">

https://github.com/user-attachments/assets/b470ab3b-de58-49e6-9100-67c682a9fa25






- 폴더별 요약 칸 조정 -> 양쪽 정렬로 수정
- 폴더 삭제 시 화면에 바로 반영 (삭제 시 페이지 재로딩)
- 파일 삭제 시 화면에 바로 반영 (삭제 시 페이지 재로딩)

### 세부 사항
- 사용시 적절한 멘트와 함수 전달해주면 사용 가능

## 🚀 로직 설명 및 코드 설명
 ```
{showDetails && (
                      <div className='pl-10 pr-10 pt-3 pb-3 bg-gray-100 rounded-xl shadow mb-4'>
                        {/* <div className='mt-3' style={{ width: containerWidth }}> */}
                        <span
                          className='block text-sm'
                          style={{ width: '100%', textAlign: 'justify' }}
                        >
                          {folderPortfolio}
                        </span>
                      </div>
                      // </div>
                    )}
```
-> 고친 부분 이 부분입니다!


## ➕ 그 외에 추가적으로 구현된 사항


## 🤔 테스트,검증 && 고민 사항
- 오른쪽에 각 단어의 길이가 달라서 끝나는 지점이 다 다른 것으로 보이는데 이 부분 괜찮은지

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영!! (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려하면 좋겠는 것들! (Comment)
* P3 : 기타 사소한 의견 (Chore) -->